### PR TITLE
Improve readability of Terms page

### DIFF
--- a/src/web/app/pages-static/terms-page/terms-page.component.html
+++ b/src/web/app/pages-static/terms-page/terms-page.component.html
@@ -7,15 +7,16 @@
     By using <b>TEAMMATES</b>, you agree to the following terms of use:
   </p>
   <p>
-    <b>Quality of service</b>: We take pride in our work and we shall do our best to provide good service to users. However, the service is provided "AS IS" and WITHOUT ANY WARRANTY.
-    You use TEAMMATES at your own discretion and risk and you will be solely responsible for any damages that may arise from such use.
+    ✓ <b>Quality of service</b>: <br><br>We take pride in our work and we shall do our best to provide good service to users. However, the service is provided "AS IS" and <u>WITHOUT ANY WARRANTY</u>.
+    You will use TEAMMATES at your own discretion and risk and you will be solely responsible for any damages that may arise from such use.
+	</p>
+  <p>
+    ✓ <b>Changes to the service</b>: <br><br>We strive to improve TEAMMATES continuously and provide its services free for as long as we can. However, please note that TEAMMATES services may change or be terminated at our discretion.
   </p>
   <p>
-    <b>Changes to the service</b>: We strive to improve TEAMMATES continuously and provide its services free for as long as we can. However, TEAMMATES services may change or be terminated at our discretion.
-  </p>
-  <p>
-    <b>Security and privacy of data</b>: Our data are stored in Google servers and are protected by the same security mechanisms that protect Google data.
-    However, you are advised not to store in TEAMMATES any 'sensitive' data such as credit card numbers and passwords.<br>
-    We do not use TEAMMATES data for research. Only TEAMMATES administrators (not developers) have access to data, for performance monitoring and troubleshooting purposes.
-  </p>
+    ✓ <b>Security and privacy of data</b>: </p>
+		<ol><li> Our data are stored in Google servers and are protected by the same security mechanisms that protect Google data.
+    However, you are advised not to store any 'sensitive' data such as credit card numbers and passwords in TEAMMATES.</li>
+    <li>We do not use TEAMMATES data for research. Only TEAMMATES administrators (not developers) have access to data for performance monitoring and troubleshooting purposes.</li>
+		</ol>
 </main>

--- a/src/web/app/pages-static/terms-page/terms-page.component.scss
+++ b/src/web/app/pages-static/terms-page/terms-page.component.scss
@@ -1,3 +1,8 @@
 img {
   margin: 20px 0;
 }
+
+ol {
+    padding-left: 1.8em; 
+}
+


### PR DESCRIPTION
Issue: Current Terms page for the product website seems rather cluttered and may not be appealing to read for users.

Solution: Add spacings and make Terms page more aesthetically appealing to users. This also makes the website look more professional to attract more users.
